### PR TITLE
Added ability to shut down the START/DONE sidekiq calls

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,13 @@ And then execute:
   ```
   defaults to: `Rails.application.class.parent.to_s.underscore`
 
+4. To activate `Start/Done` lines for each worker instantiation (turned off by default)
+  ```ruby
+  # config/environments/production.rb
+  MyApp::Application.configure do
+    config.applicaster_logger.verbose = true
+  end
+
 ## Contributing
 
 1. Fork it

--- a/lib/applicaster/sidekiq/middleware.rb
+++ b/lib/applicaster/sidekiq/middleware.rb
@@ -18,7 +18,7 @@ module Applicaster
                   args: item['args'].inspect,
                   latency: ::Sidekiq::Job.new(::Sidekiq.dump_json(item)).latency,
                   memory: memory
-                }))
+                })) if verbose?
 
                 start = Time.now
 
@@ -35,7 +35,7 @@ module Applicaster
                   args: item['args'].inspect,
                   runtime: elapsed(start),
                   memory: memory
-                }))
+                })) if verbose?
               rescue Exception => e
                 logger.error(filter_fields({
                   message: "Fail: #{worker.class.to_s} JID-#{item['jid']}",
@@ -102,6 +102,10 @@ module Applicaster
             end
 
             data
+          end
+
+          def verbose?
+            ::Rails.application.config.applicaster_logger.verbose
           end
         end
       end


### PR DESCRIPTION
@vitalis 
So we noticed lately that we are logging way too much to logz.io and keep getting quota alerts.
A quick look at logz.io (.e.g last 7 days)

![image](https://cloud.githubusercontent.com/assets/2572475/24249410/ccf296da-0fdb-11e7-85dd-719bb0363eba.png)

reveals that the lowest hanging fruit is (as we have discussed with @vinagrito in the past) the excessive `Start`, `Done` log lines that Sidekiq logs for every background job worker.

What this PR does is stop logging those lines by default. If an application needs to log those lines then it has to specify so explicitly by adding the following config line
```
  config.applicaster_logger.verbose = true
```