### PR TITLE
separarte control over the sidekiq logging level

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ And then execute:
   ```ruby
   # config/environments/production.rb
   MyApp::Application.configure do
-    config.applicaster_logger.sidekiq_level = Logger::ERROR # Logger::DEBUG etc..
+    config.applicaster_logger.sidekiq_log_level = Logger::ERROR # Logger::DEBUG etc..
   end
   ```
   defaults to `applicaster_logger.level`

--- a/README.md
+++ b/README.md
@@ -47,6 +47,16 @@ And then execute:
   ```
   defaults to: `Rails.application.class.parent.to_s.underscore`
 
+4. To separately control the Sidekiq logging level:
+
+  ```ruby
+  # config/environments/production.rb
+  MyApp::Application.configure do
+    config.applicaster_logger.sidekiq_level = Logger::ERROR # Logger::DEBUG etc..
+  end
+  ```
+  defaults to `applicaster_logger.level`
+
 ## Contributing
 
 1. Fork it

--- a/lib/applicaster/sidekiq/middleware.rb
+++ b/lib/applicaster/sidekiq/middleware.rb
@@ -65,7 +65,7 @@ module Applicaster
               begin
                 applicaster_logger = ::Rails.application.config.applicaster_logger
                 logger = LogStashLogger.new(applicaster_logger.logstash_config)
-                logger.level = applicaster_logger.level
+                logger.level = applicaster_logger.sidekiq_level || applicaster_logger.level
                 logger.formatter = Applicaster::Logger::Formatter.new(facility: "sidekiq")
                 logger
               end

--- a/lib/applicaster/sidekiq/middleware.rb
+++ b/lib/applicaster/sidekiq/middleware.rb
@@ -65,7 +65,7 @@ module Applicaster
               begin
                 applicaster_logger = ::Rails.application.config.applicaster_logger
                 logger = LogStashLogger.new(applicaster_logger.logstash_config)
-                logger.level = applicaster_logger.sidekiq_level || applicaster_logger.level
+                logger.level = applicaster_logger.sidekiq_log_level || applicaster_logger.level
                 logger.formatter = Applicaster::Logger::Formatter.new(facility: "sidekiq")
                 logger
               end


### PR DESCRIPTION
@vinagrito @vitalis 
This is another approach (pushed by @vinagrito) to silent the excessive sidekiq `Start/Done` logs.
Instead of hacking just directly set the sidekiq facility log level. 