### PR TITLE
change action_controller facility log severity

### DIFF
--- a/lib/applicaster/logger.rb
+++ b/lib/applicaster/logger.rb
@@ -10,6 +10,7 @@ module Applicaster
     def self.setup_lograge(app)
       app.config.lograge.enabled = true
       app.config.lograge.formatter = Lograge::Formatters::Logstash.new
+      app.config.lograge.log_level = :debug
       app.config.lograge.custom_options = lambda do |event|
         {
           params: event.payload[:params].except(*INTERNAL_PARAMS).inspect,
@@ -24,7 +25,6 @@ module Applicaster
 
     def self.setup_logger(app)
       logstash_config = app.config.applicaster_logger.logstash_config
-
       app.config.logger = LogStashLogger.new(logstash_config)
       app.config.logger.level = app.config.applicaster_logger.level
       app.config.logger.formatter =

--- a/lib/applicaster/logger/version.rb
+++ b/lib/applicaster/logger/version.rb
@@ -1,5 +1,5 @@
 module Applicaster
   module Logger
-    VERSION = "0.6.6"
+    VERSION = "0.6.7"
   end
 end


### PR DESCRIPTION
@vinagrito I think this should silence all the `[200] GET` calls even if we set the applicaster2 log level back to `info`. Reason being that the `log_level` variable sets the level in which logs **_are written_**, as opposed to `level` which sets the threshold.