### PR TITLE
remove backtrace from sidekiq exceptions and truncate message

### DIFF
--- a/lib/applicaster/logger.rb
+++ b/lib/applicaster/logger.rb
@@ -84,7 +84,7 @@ module Applicaster
     # grapheme clusters ("perceptual characters") by truncating at combining
     # characters.
     # Code taken from activesupport/lib/active_support/core_ext/string/filters.rb
-    def truncate_bytes(text, truncate_at, omission: "…")
+    def truncate_bytes(text, truncate_at, omission: "...")
       omission ||= ""
 
       case

--- a/lib/applicaster/logger.rb
+++ b/lib/applicaster/logger.rb
@@ -78,5 +78,37 @@ module Applicaster
     def self.current_thread_data
       Thread.current[:logger_thread_data] || {}
     end
+
+    # Truncates +text+ to at most <tt>bytesize</tt> bytes in length without
+    # breaking string encoding by splitting multibyte characters or breaking
+    # grapheme clusters ("perceptual characters") by truncating at combining
+    # characters.
+    # Code taken from activesupport/lib/active_support/core_ext/string/filters.rb
+    def truncate_bytes(text, truncate_at, omission: "…")
+      omission ||= ""
+
+      case
+      when text.bytesize <= truncate_at
+        text.dup
+      when omission.bytesize > truncate_at
+        raise ArgumentError, "Omission #{omission.inspect} is #{omission.bytesize}, larger than the truncation length of #{truncate_at} bytes"
+      when omission.bytesize == truncate_at
+        omission.dup
+      else
+        text.class.new.tap do |cut|
+          cut_at = truncate_at - omission.bytesize
+
+          text.scan(/\X/) do |grapheme|
+            if cut.bytesize + grapheme.bytesize <= cut_at
+              cut << grapheme
+            else
+              break
+            end
+          end
+
+          cut << omission
+        end
+      end
+    end
   end
 end

--- a/lib/applicaster/logger.rb
+++ b/lib/applicaster/logger.rb
@@ -84,7 +84,7 @@ module Applicaster
     # grapheme clusters ("perceptual characters") by truncating at combining
     # characters.
     # Code taken from activesupport/lib/active_support/core_ext/string/filters.rb
-    def truncate_bytes(text, truncate_at, omission: "...")
+    def self.truncate_bytes(text, truncate_at, omission: "...")
       omission ||= ""
 
       case

--- a/lib/applicaster/sidekiq/exception_logger.rb
+++ b/lib/applicaster/sidekiq/exception_logger.rb
@@ -8,7 +8,7 @@ module Applicaster
         event = log_context(item, queue).merge({
           message: "Fail: #{item['class']} JID-#{item['jid']}",
           exception_class: exception.class.to_s,
-          exception_message: exception.message.to_s,
+          exception_message: Applicaster::Logger.truncate_bytes(exception.message.to_s, 500),
         })
         logger.info(event)
       end

--- a/lib/applicaster/sidekiq/middleware.rb
+++ b/lib/applicaster/sidekiq/middleware.rb
@@ -48,7 +48,7 @@ module Applicaster
                   args: item['args'].inspect,
                   runtime: elapsed(start),
                   exception_class: e.class.to_s,
-                  exception_message: Applicaster::Logger.truncate_bytes(e.message.to_s, 500)
+                  exception_message: Applicaster::Logger.truncate_bytes(e.message.to_s, 500),
                   memory: memory
                 }))
 

--- a/lib/applicaster/sidekiq/middleware.rb
+++ b/lib/applicaster/sidekiq/middleware.rb
@@ -48,8 +48,7 @@ module Applicaster
                   args: item['args'].inspect,
                   runtime: elapsed(start),
                   exception_class: e.class.to_s,
-                  exception_message: e.message,
-                  backtrace: e.backtrace.join("\n"),
+                  exception_message: Applicaster::Logger.truncate_bytes(e.message.to_s, 500)
                   memory: memory
                 }))
 


### PR DESCRIPTION
`applicaster-logger` is currently sending all the backtrace of exceptions raised in sidekiq jobs.
This causes to log event to exceed the maximum allowed values in logz.io and is also causing excessive usage of our log quota.
Exceptions should be tracked in other systems like honeybadger or sentry.

This PR removes those backtraces and also truncates long exception messages.